### PR TITLE
proper 404 page, layout and nav

### DIFF
--- a/components/layout/index.tsx
+++ b/components/layout/index.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from "react";
+import Nav from "@/components/nav/Nav";
+
+interface LayoutProps {
+	children: ReactNode;
+}
+const Layout = ({ children }: LayoutProps) => {
+	return (
+		<>
+			<Nav />
+			<main>{children}</main>
+		</>
+	);
+};
+
+export default Layout;

--- a/components/nav/NavItem.tsx
+++ b/components/nav/NavItem.tsx
@@ -1,19 +1,20 @@
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { ReactNode } from "react";
 
 interface NavItemProps {
 	children: ReactNode;
-	primary?: boolean;
 	link: string;
 }
 
-const NavItem = ({ primary, children, link }: NavItemProps) => {
+const NavItem = ({ children, link }: NavItemProps) => {
+	const router = useRouter();
 	return (
 		<li>
 			<Link
 				href={link}
 				className={`font-medium tracking-wide ${
-					primary ? "text-brand-black" : "text-gray-700"
+					router.pathname === link ? "text-indigo-600" : "text-gray-700"
 				}  transition-colors duration-200 hover:text-deep-purple-accent-400`}
 			>
 				{children}

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,12 +1,9 @@
 import Head from "next/head";
-import { FC } from "react";
-
-import Logo from "@/assets/Logo";
-import Nav from "@/components/nav/Nav";
+import Link from "next/link";
 
 const PageHead = () => (
 	<Head>
-		<title>Coming Soon | CodeNight</title>
+		<title>Not Found | CodeNight</title>
 		<meta
 			name="description"
 			content="Community of Ethiopian developers to showcase their projects"
@@ -15,28 +12,28 @@ const PageHead = () => (
 	</Head>
 );
 
-const HeroSection = () => (
-	<section className="px-4 py-32 mx-auto max-w-7xl">
-		<div className="w-full mx-auto text-left md:w-11/12 xl:w-8/12 md:text-center">
-			<div className="flex items-center justify-center w-20 h-20 mx-auto mb-6 rounded-full bg-gray-100">
-				<Logo />
-			</div>
-			<h1 className="mb-3 text-4xl font-bold text-gray-900 md:text-5xl md:leading-tight md:font-extrabold">
-				Coming Soon
-			</h1>
-			<p className="mb-6 text-lg text-gray-500 md:text-xl md:leading-normal">
-				Stay tuned for more updates
-			</p>
-		</div>
-	</section>
-);
-
 export default function ComingSoon() {
 	return (
 		<>
 			<PageHead />
-			<main>
-				<HeroSection />
+			<main className="grid min-h-full place-items-center bg-white px-6 py-24 sm:py-32 lg:px-8">
+				<div className="text-center">
+					<p className="text-base font-semibold text-indigo-600">404</p>
+					<h1 className="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+						Page not found
+					</h1>
+					<p className="mt-6 text-base leading-7 text-gray-600">
+						Sorry, we couldn’t find the page you’re looking for.
+					</p>
+					<div className="mt-10 flex items-center justify-center gap-x-6">
+						<Link
+							href="/"
+							className="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+						>
+							Go back home
+						</Link>
+					</div>
+				</div>
 			</main>
 		</>
 	);

--- a/pages/about-us/index.tsx
+++ b/pages/about-us/index.tsx
@@ -1,0 +1,42 @@
+import Head from "next/head";
+
+import Logo from "@/assets/Logo";
+import Layout from "@/components/layout";
+
+const PageHead = () => (
+	<Head>
+		<title>Coming Soon | CodeNight</title>
+		<meta
+			name="description"
+			content="Community of Ethiopian developers to showcase their projects"
+		/>
+		<link rel="icon" href="/favicon.ico" />
+	</Head>
+);
+
+const HeroSection = () => (
+	<section className="px-4 py-32 mx-auto max-w-7xl">
+		<div className="w-full mx-auto text-left md:w-11/12 xl:w-8/12 md:text-center">
+			<div className="flex items-center justify-center w-20 h-20 mx-auto mb-6 rounded-full bg-gray-100">
+				<Logo />
+			</div>
+			<h1 className="mb-3 text-4xl font-bold text-gray-900 md:text-5xl md:leading-tight md:font-extrabold">
+				Coming Soon
+			</h1>
+			<p className="mb-6 text-lg text-gray-500 md:text-xl md:leading-normal">
+				Stay tuned for more updates
+			</p>
+		</div>
+	</section>
+);
+
+export default function ComingSoon() {
+	return (
+		<>
+			<PageHead />
+			<Layout>
+				<HeroSection />
+			</Layout>
+		</>
+	);
+}

--- a/pages/contact-us/index.tsx
+++ b/pages/contact-us/index.tsx
@@ -1,0 +1,42 @@
+import Head from "next/head";
+
+import Logo from "@/assets/Logo";
+import Layout from "@/components/layout";
+
+const PageHead = () => (
+	<Head>
+		<title>Coming Soon | CodeNight</title>
+		<meta
+			name="description"
+			content="Community of Ethiopian developers to showcase their projects"
+		/>
+		<link rel="icon" href="/favicon.ico" />
+	</Head>
+);
+
+const HeroSection = () => (
+	<section className="px-4 py-32 mx-auto max-w-7xl">
+		<div className="w-full mx-auto text-left md:w-11/12 xl:w-8/12 md:text-center">
+			<div className="flex items-center justify-center w-20 h-20 mx-auto mb-6 rounded-full bg-gray-100">
+				<Logo />
+			</div>
+			<h1 className="mb-3 text-4xl font-bold text-gray-900 md:text-5xl md:leading-tight md:font-extrabold">
+				Coming Soon
+			</h1>
+			<p className="mb-6 text-lg text-gray-500 md:text-xl md:leading-normal">
+				Stay tuned for more updates
+			</p>
+		</div>
+	</section>
+);
+
+export default function ComingSoon() {
+	return (
+		<>
+			<PageHead />
+			<Layout>
+				<HeroSection />
+			</Layout>
+		</>
+	);
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head";
 
 import Logo from "@/assets/Logo";
-import Nav from "@/components/nav/Nav";
+import Layout from "@/components/layout";
 
 const PageHead = () => (
 	<Head>
@@ -231,13 +231,12 @@ export default function Home() {
 	return (
 		<>
 			<PageHead />
-			<main>
-				<Nav />
+			<Layout>
 				<HeroSection />
 				<Programs />
 				<AboutUs />
 				<Partners />
-			</main>
+			</Layout>
 			<StickyBottomBanner />
 		</>
 	);

--- a/pages/read/index.tsx
+++ b/pages/read/index.tsx
@@ -1,0 +1,42 @@
+import Head from "next/head";
+
+import Logo from "@/assets/Logo";
+import Layout from "@/components/layout";
+
+const PageHead = () => (
+	<Head>
+		<title>Coming Soon | CodeNight</title>
+		<meta
+			name="description"
+			content="Community of Ethiopian developers to showcase their projects"
+		/>
+		<link rel="icon" href="/favicon.ico" />
+	</Head>
+);
+
+const HeroSection = () => (
+	<section className="px-4 py-32 mx-auto max-w-7xl">
+		<div className="w-full mx-auto text-left md:w-11/12 xl:w-8/12 md:text-center">
+			<div className="flex items-center justify-center w-20 h-20 mx-auto mb-6 rounded-full bg-gray-100">
+				<Logo />
+			</div>
+			<h1 className="mb-3 text-4xl font-bold text-gray-900 md:text-5xl md:leading-tight md:font-extrabold">
+				Coming Soon
+			</h1>
+			<p className="mb-6 text-lg text-gray-500 md:text-xl md:leading-normal">
+				Stay tuned for more updates
+			</p>
+		</div>
+	</section>
+);
+
+export default function ComingSoon() {
+	return (
+		<>
+			<PageHead />
+			<Layout>
+				<HeroSection />
+			</Layout>
+		</>
+	);
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,5 @@ module.exports = {
 			},
 		},
 	},
-	plugins: [
-      require('@tailwindcss/aspect-ratio'),
-	],
+	plugins: [require("@tailwindcss/aspect-ratio")],
 };


### PR DESCRIPTION
### Changes I made
- Made a layout component
> The navbar is now visible by simply wrapping any page in the Layout component.

- The NavBar
> The navbar now displays the active color for the current page. 

- Proper 404 page
- Made coming soon for all pages
> I copied all of the coming soon codes from the 404 page and created an empty page with the coming soon code for the _about-us_ _contact-us_ _read_ pages.

![Screenshot 2023-04-04 10 30 09 PM](https://user-images.githubusercontent.com/59355292/229905123-2ec75f1a-cbfa-4f2c-824a-64ad1c6978eb.png)

![Screenshot 2023-04-04 10 30 20 PM](https://user-images.githubusercontent.com/59355292/229905178-ab4960af-2f44-4dfe-b240-a27a76947bf4.png)

![Screenshot 2023-04-04 10 29 41 PM](https://user-images.githubusercontent.com/59355292/229905215-d050c5f0-3a29-4f28-8fd3-c10efb1e24a2.png)

