### PR TITLE
Add pre commit hooks

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,0 @@
-{
-  "**/*.{js,ts}": ["npx rome check --config .romerc.js"],
-  "**/*": ["npx prettier --write"]
-}

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,0 +1,4 @@
+{
+  "**/*.{js,ts}": ["npx rome check --config .romerc.js"],
+  "**/*": ["npx prettier --write"]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+repos:
+  - repo: https://github.com/okonet/lint-staged
+    rev: v11.0.0
+    hooks:
+      - id: lint-staged
+        name: lint-staged
+        entry: npx
+        args: [lint-staged]
+
+  - repo: local
+    hooks:
+      - id: rome
+        name: Rome
+        entry: npx
+        args: [rome, "check", "./.romerc.js", "."]
+        language: system
+        stages: [commit]
+
+      - id: run-tests
+        name: Run Tests
+        entry: npm
+        args: [run, test]
+        language: system
+        pass_filenames: false
+        stages: [commit]
+
+      - id: build
+        name: Build
+        entry: npm
+        args: [run, build]
+        language: system
+        pass_filenames: false
+        stages: [push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: rome
         name: Rome
         entry: npx
-        args: [rome, "check", "./.romerc.js", "."]
+        args: [rome, "check", "."]
         language: system
         stages: [commit]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
-  - repo: https://github.com/okonet/lint-staged
-    rev: v11.0.0
-    hooks:
-      - id: lint-staged
-        name: lint-staged
-        entry: npx
-        args: [lint-staged]
 
   - repo: local
     hooks:
       - id: rome
         name: Rome
         entry: npx
-        args: [rome, "check", "."]
+        args: [rome, "format", ".", "--write"]
+        language: system
+        stages: [commit]
+
+      - id: lint
+        name: Next-Lint
+        entry: npx
+        args: [next, "lint"]
         language: system
         stages: [commit]
 
@@ -26,8 +26,8 @@ repos:
 
       - id: build
         name: Build
-        entry: npm
-        args: [run, build]
+        entry: npx
+        args: [next, build]
         language: system
         pass_filenames: false
         stages: [push]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before you start working on the project, please follow these steps:
 2. Clone the repository to your local machine
 3. Install the required dependencies by running `pnpm install`
 4. Install [pre-commit](https://pre-commit.com/)
-5. Run `pre-commit install` on the base directory
+5. Run `pre-commit install && pre-commit install --hook-type pre-push` on the base directory
 6. Create a new branch for your changes
 
 ## Making Changes
@@ -19,8 +19,8 @@ When making changes to the code, please keep the following in mind:
 
 1. Write clear and concise commit messages
 2. Follow the existing code style and conventions
-3. Format your code using Rome by running `pnpm run format:write`
-4. Run the linter to ensure that your changes follow our code style by running `pnpm run lint:next` and `pnpm run lint:rome`
+3. You code will be formatted using pre-commits before you commit any changes if you want to run it manually please run `pnpm run format:write`
+4. A linter will also run before every commit to ensure that your changes follow our code style if you want to perform manual check please run `pnpm run lint:next` and `pnpm run lint:rome`
 5. Check that your changes type-check by running `pnpm run type:check`
 6. Update the documentation if necessary
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,9 @@ Before you start working on the project, please follow these steps:
 1. Fork the repository to your own account
 2. Clone the repository to your local machine
 3. Install the required dependencies by running `pnpm install`
-4. Create a new branch for your changes
+4. Install [pre-commit](https://pre-commit.com/)
+5. Run `pre-commit install` on the base directory
+6. Create a new branch for your changes
 
 ## Making Changes
 

--- a/components/button/IconButton.tsx
+++ b/components/button/IconButton.tsx
@@ -1,20 +1,20 @@
 import { ReactElement } from "react";
 
 interface IconButtonProps {
-	children: ReactElement;
-	onClick: () => void;
+  children: ReactElement;
+  onClick: () => void;
 }
 
 const IconButton = ({ children, onClick }: IconButtonProps) => {
-	return (
-		<button
-			onClick={onClick}
-			type='button'
-			className='text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 border border-gray-300 rounded-lg text-sm p-2.5'
-		>
-			{children}
-		</button>
-	);
+  return (
+    <button
+      onClick={onClick}
+      type="button"
+      className="text-gray-500 hover:bg-gray-100   focus:outline-none focus:ring-4 focus:ring-gray-200 border border-gray-300 rounded-lg text-sm p-2.5"
+    >
+      {children}
+    </button>
+  );
 };
 
 export default IconButton;

--- a/components/button/IconButton.tsx
+++ b/components/button/IconButton.tsx
@@ -1,20 +1,20 @@
 import { ReactElement } from "react";
 
 interface IconButtonProps {
-  children: ReactElement;
-  onClick: () => void;
+	children: ReactElement;
+	onClick: () => void;
 }
 
 const IconButton = ({ children, onClick }: IconButtonProps) => {
-  return (
-    <button
-      onClick={onClick}
-      type="button"
-      className="text-gray-500 hover:bg-gray-100   focus:outline-none focus:ring-4 focus:ring-gray-200 border border-gray-300 rounded-lg text-sm p-2.5"
-    >
-      {children}
-    </button>
-  );
+	return (
+		<button
+			onClick={onClick}
+			type="button"
+			className="text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 border border-gray-300 rounded-lg text-sm p-2.5"
+		>
+			{children}
+		</button>
+	);
 };
 
 export default IconButton;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,5 @@ module.exports = {
 			},
 		},
 	},
-	plugins: [
-      require('@tailwindcss/aspect-ratio'),
-	],
+	plugins: [require("@tailwindcss/aspect-ratio")],
 };


### PR DESCRIPTION

Closes #18 

### Changes
Added pre-commit hooks for Rome, Next-Lint, Run Tests, and Build in .pre-commit-config.yaml. The hooks are configured to run on commit and push stages and updated the contribution doc accordingly.

### Description
This pull request adds pre-commit hooks to ensure consistent code formatting, linting, building and testing before committing and pushing changes. The following hooks have been added:

Rome: to format the code using Rome
Next-Lint: to run linting for the Next.js project
Run Tests: to run tests using npm run test
Build: to build the Next.js project

These hooks will help to ensure that code quality is maintained and prevent common errors and issues from being introduced.

Usage
To use these pre-commit hooks, ensure that you have pre-commit installed:

```shell
pip install pre-commit   # other options on https://pre-commit.com/
```

Then, run the following command in the root directory of your project:
```shell
pre-commit install && pre-commit install --hook-type pre-push
``` 
This will install all hooks with the stages field set to either commit or push. The --hook-type option is used to specify commit hooks

After running this command, all hooks in your .pre-commit-config.yaml file will be installed and ready to use. You can then run git commit or git push as usual, and the pre-commit hooks will automatically run before the commit or push is completed.
#### Example output when committing 
<img width="580" alt="Screenshot 2023-04-05 at 16 43 18" src="https://user-images.githubusercontent.com/34884388/230123992-72649719-66d5-47d5-b2e5-68fffd399a9e.png">

#### Example output when pushing 
<img width="594" alt="Screenshot 2023-04-05 at 16 43 08" src="https://user-images.githubusercontent.com/34884388/230123954-c9df98c2-b1f5-4b8c-a4cb-9efafffc91f4.png">
